### PR TITLE
another way of array declare

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ There are some basic types available for TypeScript. Such as `string`, `number`,
 let x: number = 5;
 let name: string = "John Doe";
 let showErrorMsg: boolean = true;
+let numbers: number[] = [1, 2, 3];
 let numbers: Array<number> = [1, 2, 3];
 let students: Array<string> = ["John Doe", "Michael"];
 


### PR DESCRIPTION
Array types can be written in one of two ways. In the first, you use the type of the elements followed by [] to denote an array of that element type:

let list: number[] = [1, 2, 3];

The second way uses a generic array type, Array<elemType>:

let list: Array<number> = [1, 2, 3];